### PR TITLE
Fixed exclude path when public dir is not set

### DIFF
--- a/files-backup-without-uploads.sh
+++ b/files-backup-without-uploads.sh
@@ -114,11 +114,16 @@ fi
 
 # path to be excluded from the backup
 # no trailing slash, please
+EXCLUDE_BASE_PATH=${DOMAIN}
+if [ "$PUBLIC_DIR" != "" ]; then
+    EXCLUDE_BASE_PATH=${EXCLUDE_BASE_PATH}/${PUBLIC_DIR}
+fi  
+
 declare -A EXC_PATH
-EXC_PATH[1]=${DOMAIN}/${PUBLIC_DIR}/wp-content/cache
-EXC_PATH[2]=${DOMAIN}/${PUBLIC_DIR}/wp-content/debug.log
-EXC_PATH[3]=${DOMAIN}/${PUBLIC_DIR}/.git
-EXC_PATH[4]=${DOMAIN}/${PUBLIC_DIR}/wp-content/uploads
+EXC_PATH[1]=${EXCLUDE_BASE_PATH}/wp-content/cache
+EXC_PATH[2]=${EXCLUDE_BASE_PATH}/wp-content/debug.log
+EXC_PATH[3]=${EXCLUDE_BASE_PATH}/.git
+EXC_PATH[4]=${EXCLUDE_BASE_PATH}/wp-content/uploads
 # need more? - just use the above format
 
 EXCLUDES=''

--- a/full-backup.sh
+++ b/full-backup.sh
@@ -101,10 +101,15 @@ fi
 
 # path to be excluded from the backup
 # no trailing slash, please
+EXCLUDE_BASE_PATH=${DOMAIN}
+if [ "$PUBLIC_DIR" != "" ]; then
+    EXCLUDE_BASE_PATH=${EXCLUDE_BASE_PATH}/${PUBLIC_DIR}
+fi  
+
 declare -A EXC_PATH
-EXC_PATH[1]=${DOMAIN}/${PUBLIC_DIR}/wp-content/cache
-EXC_PATH[2]=${DOMAIN}/${PUBLIC_DIR}/wp-content/debug.log
-EXC_PATH[3]=${DOMAIN}/${PUBLIC_DIR}/.git
+EXC_PATH[1]=${EXCLUDE_BASE_PATH}/wp-content/cache
+EXC_PATH[2]=${EXCLUDE_BASE_PATH}/wp-content/debug.log
+EXC_PATH[3]=${EXCLUDE_BASE_PATH}/.git
 # need more? - just use the above format
 
 EXCLUDES=''


### PR DESCRIPTION
When public dir is empty the exclude path contains a double slash.
This fixed it for me, but I haven't tested it with a public dir set.

You might want to review merge if you like :)